### PR TITLE
Test for library functions

### DIFF
--- a/csigsafe.cc
+++ b/csigsafe.cc
@@ -862,7 +862,7 @@ void css_function::process_gimple_call(css_bb &status,gimple * stmt, bool &all_o
 	if (!called_function_name)
 		return;
 	int8_t return_number = RC_ASYNCH_SAFE;
-	if (DECL_INITIAL  (fn_decl))
+	if (DECL_INITIAL  (fn_decl) && !DECL_EXTERNAL(fn_decl))
 	{
 		// in case of recurse, do nothing
 		if (strcmp(get_name(this->get_fnc_decl()),called_function_name)==0)


### PR DESCRIPTION
Testing DECL_INITIAL  (fn_decl) wasn't suitable for c++ functions, it often tried to scan the inside of these functions. Check for !DECL_EXTERNAL(fn_decl) solves this (it checks if the function definition is aviable).